### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/pages/unified-booking.html
+++ b/pages/unified-booking.html
@@ -688,6 +688,17 @@
     // =========================
     // CHECKOUT / SUCCESS DEMO
     // =========================
+    // Escape HTML meta-characters to prevent XSS
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/\//g, '&#x2F;');
+    }
+
     function buildSuccessDetails(overrides){
       // Supports URL param overrides for backwards compatibility
       const params = new URLSearchParams(location.search);
@@ -703,7 +714,7 @@
       const addons = addonsParam > 0 ? addonsParam : (overrides?.addons ?? 0);
 
       const html = `
-        <div class="detail-row"><span>Treatment Selected:</span><span>${name}</span></div>
+        <div class="detail-row"><span>Treatment Selected:</span><span>${escapeHTML(name)}</span></div>
         ${addons ? `<div class="detail-row"><span>Add‑ons Selected:</span><span>${addons} enhancement${addons!==1?'s':''}</span></div>` : ''}
         <div class="detail-row"><span>Service Fee:</span><span>${money(price)}</span></div>
         <div class="detail-row"><span>Travel Fee:</span><span>${money(travel)}</span></div>


### PR DESCRIPTION
Potential fix for [https://github.com/Icantcode45/finalstaydripped/security/code-scanning/29](https://github.com/Icantcode45/finalstaydripped/security/code-scanning/29)

To fix the vulnerability, we must ensure that any user-controlled data interpolated into HTML and injected via `innerHTML` is properly escaped. The best way is to escape meta-characters in `name` (and any other user-controlled variables) before using them in the template literal. This can be done by creating a utility function (e.g., `escapeHTML`) that replaces `<`, `>`, `&`, `"`, `'`, and `/` with their respective HTML entities. The fix should be applied in the region where `name` is interpolated into the HTML string (line 706), and the escaping function should be defined in the same file.

**Required changes:**
- Add an `escapeHTML` function to the script.
- Use `escapeHTML(name)` in the template literal for `html` in `buildSuccessDetails`.
- Optionally, review other interpolated variables for similar risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
